### PR TITLE
feat: add card delete function to delete button (#9)

### DIFF
--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnDataSource.swift
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnDataSource.swift
@@ -29,4 +29,11 @@ class ColumnDataSource : NSObject, UITableViewDataSource {
         cell.update(content: datas.cellDataContent(index: indexPath.section))
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete{
+            datas.remove(index: indexPath.section)
+            tableView.deleteSections(IndexSet(integer: indexPath.section), with: .fade)
+        }
+    }
 }

--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnView.storyboard
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnView.storyboard
@@ -71,7 +71,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="32" id="gNC-xa-zUA"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -90,7 +90,7 @@
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="ytY-Ij-K93"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <fontDescription key="fontDescription" type="system" weight="ultraLight" pointSize="12"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnViewController.swift
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/Controllers/ColumnViewController.swift
@@ -35,6 +35,8 @@ class ColumnViewController : UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         viewInit()
+//        columnTableView.estimatedRowHeight = 108
+//        columnTableView.rowHeight = UITableView.automaticDimension
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -67,6 +69,7 @@ class ColumnViewController : UIViewController {
         guard let currentModalVC = currentModalViewController else { return }
         cellDataManager.add(cellData: currentModalVC.makeCellData())
         columnTableView.insertSections(IndexSet(integer: columnTableView.numberOfSections), with: .automatic)
+        print(cellDataManager.currentDatasCount())
         currentModalVC.set(active: false)
         self.currentModalViewController = nil
     }

--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/Model/ColumnDatas.swift
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/Model/ColumnDatas.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class ColumnDatas : DataManager{
+    
     private var cellDatas : [CellData]
     
     init() {
@@ -16,6 +17,9 @@ class ColumnDatas : DataManager{
     
     func add(cellData : CellData) -> Void{
         cellDatas.append(cellData)
+    }
+    func remove(index : Int) -> Void {
+        cellDatas.remove(at: index)
     }
     
     func currentDatasCount() -> Int{

--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/Model/DataManager.swift
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/Model/DataManager.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol DataManager {
     func currentDatasCount() -> Int
     func add(cellData : CellData) -> Void
+    func remove(index : Int) -> Void
     func cellDataTitle(index : Int) -> String
     func cellDataContent(index : Int) -> String
 }

--- a/frontend/ToDoListApp/ToDoListApp/ColumnSection/View/ColumnCell.swift
+++ b/frontend/ToDoListApp/ToDoListApp/ColumnSection/View/ColumnCell.swift
@@ -30,5 +30,4 @@ class ColumnCell : UITableViewCell {
 }
 
 extension ColumnCell {
-    
 }


### PR DESCRIPTION
## 작업 내용
- [x] 카드 왼쪽 슬라이드 시 "삭제" 버튼이 튀어나온다.
- [x]  삭제 버튼 pushed : UI에서 Delete
- [ ] 삭제 버튼 pushed : Network 성공 시, UI에서도 Delete
- [ ] 서버에서 삭제 실패 시 로컬에서 삭제 실패 메시지 출력

### 고민과 해결
델리게이트 함수가 있어서 크게 고민은 안했습니다. 다만, 삭제 할때 datasource의 datas가 달라지는 걸 따지지 않으면 앱이 강제종료 되어버렸습니다. 그래서 datas에 remove 함수를 넣어주었습니다.

### 추가사항
현재 네트워크가 준비되어있지 않은 관계로 네트워크를 제외하고 처리하였습니다.